### PR TITLE
Support render for AnimatedRoute

### DIFF
--- a/src/AnimatedRoute.js
+++ b/src/AnimatedRoute.js
@@ -12,7 +12,7 @@ function getKey({ pathname }, path, exact) {
   return matchPath(pathname, { exact, path }) ? 'match' : 'no-match';
 }
 
-const AnimatedRoute = ({ component, path, exact, ...routeTransitionProps }) => (
+const AnimatedRoute = ({ render, component, path, exact, ...routeTransitionProps }) => (
   <Route
     render={({ location, match }) => (
       <RouteTransition {...routeTransitionProps}>
@@ -22,6 +22,7 @@ const AnimatedRoute = ({ component, path, exact, ...routeTransitionProps }) => (
           exact={exact}
           location={location}
           component={component}
+          render={render}
         />
       </RouteTransition>
     )}


### PR DESCRIPTION
### First, thanks for the package.
Thanks for the really useful package allowing transitions via routes and more!

## The problem
The project I am putting this into does not use `component` in <route/> we instead use `render`
## The Fix
I noticed AnimatedRoute deals with styles and simply forwards the route props to react-router-dom. 
So I added the render prop into AnimatedRoute.
See the change [here](https://github.com/maisano/react-router-transition/pull/106/files)

React Router will ignore component if unspecified and ignore render if unspecified.

Confirmed locally, a route using component and a route using render are working.
example: 
```javascript
<Route
  render={
	(routeProps) => ( 
		<HomePage {...routeProps} />
    )}
/>
```
```javascript
<Route
  component={
	() => ( 
		<HomePage />
    )}
/>
```
 

## This correction does not have breaking changes, here is why:
React-Router checks to see if a component is specified, 
If component is not specified 
React Router implements render as shown here in the [source code](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/modules/Route.js#L65)



## Why am I using render?<br/>So that react does not create a new component every render. 
Below text is from the following [article](https://tylermcginnis.com/react-router-pass-props-to-components/):
```
When you use the component props, the router uses React.createElement to create 
a new React element from the given component. That means if you provide an inline
function to the component attribute, you would create a new component every render. 
```
also, 
```
So to recap, if you need to pass a prop to a component being rendered by React
Router, instead of using Routes component prop, use its render prop passing it 
an inline function then pass along the arguments to the element you’re creating.
```

The application I am putting this project into does not use withRouter() instead we pass the Router props into the route using render instead of component.
example: 
```javascript
<Route
  render={
	(routeProps) => ( 
		<HomePage {...routeProps} />
    )}
/>
```


